### PR TITLE
fix: use hexdigits to increase params limit

### DIFF
--- a/src/scim2_filter_parser/transpilers/sql.py
+++ b/src/scim2_filter_parser/transpilers/sql.py
@@ -180,9 +180,9 @@ class Transpiler(ast.NodeTransformer):
 
     def get_next_id(self):
         index = len(self.params)
-        if index >= len(string.ascii_lowercase):
+        if index >= len(string.hexdigits):
             raise IndexError('Too many params in query. Can not store all of them.')
-        return string.ascii_lowercase[index]
+        return string.hexdigits[index]
 
     def lookup_op(self, node_value):
         op_code = node_value.lower()


### PR DESCRIPTION
Use hexdigits instead of ascii_lowercase to store more params